### PR TITLE
update follow-redirects package - vulnerability fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "is-buffer": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "axios": "^0.24.0",
     "debug": "^3.1.0",
-    "follow-redirects": "^1.5.10",
+    "follow-redirects": "^1.14.7",
     "is-buffer": "^2.0.4",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",


### PR DESCRIPTION
This updates the version of follow-redirects in the package files, corresponding to an update that I've just run in the production server (`npm update follow-redirects --depth 2`).

@cTheDragons Thanks for notifying me about the need for this!